### PR TITLE
Initialize inhibitor-lab project structure

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,14 @@
+name: deploy-docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Placeholder for future documentation deployment steps

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# inhibitor-lab
 
+**inhibitor-lab** is the official open-source project from [appliedAIstudio](https://appliedaistudio.com) for demonstrating how to integrate and experiment with the Inhibitor service in agent-based systems.
+
+This repository is designed for developers, researchers, and teams looking to build ethical, interruptible, and auditable agents. It includes working examples, live integrations, reference patterns, and technical documentation to support safe and responsible agent development using the Inhibitor.
+
+---
+
+## What's Included
+
+- Example agents in TypeScript and Python
+- Jupyter notebooks implementing the ROA (Reason–Observe–Adjust) pattern
+- Live service integration examples with the Inhibitor API
+- Documentation for usage, design patterns, and safe deployment
+- Benchmarking folder for performance and latency tracking
+
+---
+
+## Getting Started
+
+1. Clone this repo
+2. Open notebooks or examples
+3. Follow documentation in `/docs` to start integrating
+
+> **Note**: The Inhibitor service is developed by appliedAIstudio. To learn more, visit [appliedAIstudio.com](https://appliedaistudio.com).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,3 @@
+# Benchmarks
+
+Placeholder for performance results.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,5 @@
+# Overview
+
+This project shows how to build agents that use the Inhibitor for ethical oversight, interruption, and observation. It includes both conceptual guidance and working code examples.
+
+Start with the notebooks or read about how ROA agents function in `/docs/roa-pattern.md`.

--- a/docs/roa-pattern.md
+++ b/docs/roa-pattern.md
@@ -1,0 +1,3 @@
+# ROA Pattern
+
+Details about the Reason–Observe–Adjust pattern will be documented here.

--- a/docs/using-the-inhibitor.md
+++ b/docs/using-the-inhibitor.md
@@ -1,0 +1,3 @@
+# Using the Inhibitor
+
+To connect your agent to the Inhibitor, make HTTP POST requests to the `/inhibitor` endpoint with a JSON payload. Example payloads and integration examples are included in both notebooks and `/examples/node/simple-agent.ts`.

--- a/examples/node/simple-agent.ts
+++ b/examples/node/simple-agent.ts
@@ -1,0 +1,21 @@
+// A basic TypeScript agent that sends a JSON request to the Inhibitor
+
+// Import axios for HTTP requests
+import axios from 'axios';
+
+// Define an async function that interacts with the Inhibitor
+async function runAgent() {
+  // Send a POST request to the Inhibitor service
+  const response = await axios.post('http://localhost:8787/inhibitor', {
+    // Inform the Inhibitor about the agent's contemplated action
+    text: "Agent contemplating action: buy ETH.",
+    // Choose the mode for the Inhibitor ("insight" or "performance")
+    mode: "insight"
+  });
+
+  // Display the response from the Inhibitor
+  console.log("Inhibitor response:", response.data);
+}
+
+// Start the agent
+runAgent();

--- a/notebooks/llm_feedback_agent.ipynb
+++ b/notebooks/llm_feedback_agent.ipynb
@@ -1,0 +1,18 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates a basic agent using the Reason–Observe–Adjust pattern with the Inhibitor."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/realtime_moderation_agent.ipynb
+++ b/notebooks/realtime_moderation_agent.ipynb
@@ -1,0 +1,18 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates a basic agent using the Reason–Observe–Adjust pattern with the Inhibitor."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/trader_agent_roa.ipynb
+++ b/notebooks/trader_agent_roa.ipynb
@@ -1,0 +1,18 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates a basic agent using the Reason–Observe–Adjust pattern with the Inhibitor."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- set up initial repository layout with docs, examples, benchmarks, and notebooks
- add TypeScript example demonstrating Inhibitor API usage
- include starter documentation and placeholder CI workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae17c648cc832faea1b49e1ed58315