### PR TITLE
docs: add Colab badge to agent notebook

### DIFF
--- a/notebooks/llm_feedback_agent.ipynb
+++ b/notebooks/llm_feedback_agent.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# LLM Feedback Agent with Inhibitor\n",
     "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/llm_feedback_agent.ipynb)\n",
+    "\n",
     "This notebook demonstrates how to connect a simple LLM-powered agent to the Inhibitor service.\n",
     "The agent generates responses to realistic prompts, the Inhibitor evaluates them, and the agent adjusts if needed (Reason–Observe–Adjust loop).\n",
     "\n",


### PR DESCRIPTION
## Summary
- add a Launch in Colab badge under the LLM Feedback Agent notebook title for easy open in Colab

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af290d24d0832fb9a8b2261e679c05