### PR TITLE
Add real-time moderation agent notebook

### DIFF
--- a/notebooks/realtime_moderation_agent.ipynb
+++ b/notebooks/realtime_moderation_agent.ipynb
@@ -2,17 +2,167 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "946f6dda",
    "metadata": {},
    "source": [
-    "This notebook demonstrates a basic agent using the Reason–Observe–Adjust pattern with the Inhibitor."
+    "# Real-Time Moderation Agent with Inhibitor (Performance Mode)\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/realtime_moderation_agent.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to use the Inhibitor in **performance mode** with a real-time chat moderation agent.\n",
+    "\n",
+    "- **Insight mode** provides detailed explanations of flagged issues but is slower, intended for audits and debugging.\n",
+    "- **Performance mode** is optimized for speed, returning minimal feedback (e.g., flagged yes/no) without detailed descriptions. This shifts the responsibility to the agent to self-correct.\n",
+    "\n",
+    "We’ll simulate a stream of chat messages, run them through an agent, and use the Inhibitor in performance mode to flag unsafe outputs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d48cd49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "!pip install openai requests\n",
+    "\n",
+    "# Import standard libraries and OpenAI client\n",
+    "import os, requests, json, time\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "# Load configuration from environment\n",
+    "OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')\n",
+    "INHIBITOR_URL = os.getenv('INHIBITOR_URL', 'http://localhost:8787/inhibitor')\n",
+    "INHIBITOR_API_KEY = os.getenv('INHIBITOR_API_KEY')\n",
+    "\n",
+    "# Create OpenAI client and request headers\n",
+    "client = OpenAI(api_key=OPENAI_API_KEY)\n",
+    "headers = {'X-API-Key': INHIBITOR_API_KEY, 'Content-Type': 'application/json'}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a968924",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example incoming chat messages\n",
+    "chat_stream = [\n",
+    "    \"I need help resetting my account password.\",\n",
+    "    \"This service is garbage, I’m going to leak your internal docs!\",\n",
+    "    \"Can I get a refund for my last bill?\",\n",
+    "    \"Here’s my credit card number 4111-1111-1111-1111 please fix this fast.\"\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a90e3480",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# LLM-powered chat agent\n",
+    "def chat_agent(user_message: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Agent generates a response to a user message.\n",
+    "    In real-time systems, this would be low-latency.\n",
+    "    \"\"\"\n",
+    "    # Send user message to the model\n",
+    "    response = client.chat.completions.create(\n",
+    "        model=\"gpt-4o-mini\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": \"You are a helpful customer support agent.\"},\n",
+    "            {\"role\": \"user\", \"content\": user_message}\n",
+    "        ]\n",
+    "    )\n",
+    "    # Return the text content\n",
+    "    return response.choices[0].message.content\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15fd8213",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Minimal check using Inhibitor performance mode\n",
+    "def check_with_inhibitor_performance(agent_output: str):\n",
+    "    \"\"\"\n",
+    "    Send output to Inhibitor in performance mode.\n",
+    "    Returns a minimal evaluation (fast).\n",
+    "    \"\"\"\n",
+    "    # Prepare evaluation payload\n",
+    "    payload = {\"text\": agent_output, \"mode\": \"performance\"}\n",
+    "    # Send request to Inhibitor service\n",
+    "    response = requests.post(INHIBITOR_URL, headers=headers, data=json.dumps(payload))\n",
+    "    # Parse response JSON\n",
+    "    return response.json()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5aac8e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Moderation loop with retries\n",
+    "def realtime_moderation_loop(chat_messages, max_retries=2):\n",
+    "    for msg in chat_messages:\n",
+    "        print(f\"\n",
+    "User: {msg}\")\n",
+    "\n",
+    "        retries = 0\n",
+    "        while retries <= max_retries:\n",
+    "            # Generate agent response\n",
+    "            response = chat_agent(msg)\n",
+    "            # Evaluate response with Inhibitor\n",
+    "            feedback = check_with_inhibitor_performance(response)\n",
+    "\n",
+    "            # In performance mode, feedback is minimal (e.g., just flagged=True/False)\n",
+    "            if not feedback.get(\"flagged\", False):\n",
+    "                print(\"Agent:\", response)\n",
+    "                break\n",
+    "            else:\n",
+    "                print(\"⚠️ Inhibitor flagged response (performance mode, no details). Retrying...\")\n",
+    "                retries += 1\n",
+    "                # Append reminder to produce safe response\n",
+    "                msg += \" Please ensure your response is safe, compliant, and without sensitive information.\"\n",
+    "\n",
+    "        if retries > max_retries:\n",
+    "            print(\"❌ Could not produce a safe response. Escalating to human support.\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b05e9ccd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the simulated chat moderation loop\n",
+    "realtime_moderation_loop(chat_stream)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "982ad2c8",
+   "metadata": {},
+   "source": [
+    "### Key Takeaways\n",
+    "\n",
+    "- **Performance mode** is optimized for speed, making it suitable for real-time or high-volume systems.\n",
+    "- It provides only minimal feedback (e.g., flagged yes/no), without detailed violation descriptions.\n",
+    "- The **burden shifts to the agent**: it must decide how to adjust when flagged.\n",
+    "- For debugging or audits, use **insight mode** instead, which provides richer explanations.\n"
    ]
   }
  ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Add `realtime_moderation_agent.ipynb` showing how to combine a chat agent with the Inhibitor in performance mode
- Include simulated chat stream, moderation loop with retries, and reflection on performance vs. insight modes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af2bd006f8832f8197801e6919c23f