### PR TITLE
Add Inhibitor API documentation and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inhibitor-lab
 
-**inhibitor-lab** is the official open-source project from [appliedAIstudio](https://appliedaistudio.com) for demonstrating how to integrate and experiment with the Inhibitor service in agent-based systems.
+**inhibitor-lab** is the official open-source project from [appliedAIstudio](https://www.appliedai.studio/) for demonstrating how to integrate and experiment with the Inhibitor service in agent-based systems.
 
 This repository is designed for developers, researchers, and teams looking to build ethical, interruptible, and auditable agents. It includes working examples, live integrations, reference patterns, and technical documentation to support safe and responsible agent development using the Inhibitor.
 
@@ -25,6 +25,15 @@ Explore hands-on examples of how to integrate and test the Inhibitor with differ
 - **[Data Handling Agent](notebooks/data_handling_agent.ipynb)**  
   Demonstrates safe vs unsafe handling of sensitive information (PII, HR, healthcare). Shows tradeoffs between **insight** and **performance** modes.  
   [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/data_handling_agent.ipynb)
+
+---
+
+## 🔌 API Documentation
+
+The Inhibitor service exposes a REST API for ethical evaluation, logging, and oversight.  
+Full details are available here: [docs/inhibitor-api.md](docs/inhibitor-api.md)
+
+👉 You must obtain an **Inhibitor API key** from [appliedAIstudio](https://www.appliedai.studio/) to use the service.
 
 ---
 
@@ -57,4 +66,5 @@ The Inhibitor provides two modes of operation:
 2. Open notebooks or examples  
 3. Follow documentation in `/docs` to start integrating  
 
-> **Note:** The Inhibitor service is developed by appliedAIstudio. To learn more, visit [appliedAIstudio.com](https://appliedaistudio.com).
+> **Note:** The Inhibitor service is developed by [appliedAIstudio](https://www.appliedai.studio/).
+

--- a/docs/inhibitor-api.md
+++ b/docs/inhibitor-api.md
@@ -1,0 +1,140 @@
+# Inhibitor API Documentation
+
+The Inhibitor service provides a REST API for evaluating agent outputs, monitoring logs, and ensuring ethical reasoning in real time.
+
+⚠️ **Note**: To use the API, you must have an **Inhibitor API key** issued by [appliedAIstudio](https://www.appliedai.studio/). Include it in all requests with the header:
+
+```
+X-API-Key: <your_api_key>
+```
+
+---
+
+## 🔌 Base URL
+
+Production:
+```
+https://inhibitor.infra-5ad.workers.dev
+```
+
+---
+
+## 🚀 Endpoints
+
+### 1. Health Check
+```
+GET /
+```
+- Confirms API key validity and service health.
+
+---
+
+### 2. Evaluate Output
+```
+POST /inhibitor
+```
+- Run ethical evaluation on text.
+- Modes:
+  - `insight` → detailed explanations (slower, for audits).
+  - `performance` → minimal feedback (fast, for real-time).
+
+**Request Example:**
+```http
+POST /inhibitor
+X-API-Key: <your_api_key>
+Content-Type: application/json
+
+{
+  "text": "Here’s my account number 1234-5678-9012",
+  "mode": "insight"
+}
+```
+
+**Response Example (Insight Mode):**
+
+```json
+{
+  "result": {
+    "flagged": true,
+    "category": "pii_leakage",
+    "explanation": "Detected account number being repeated.",
+    "severity": 3
+  }
+}
+```
+
+**Response Example (Performance Mode):**
+
+```json
+{
+  "result": {
+    "flagged": true
+  }
+}
+```
+
+---
+
+### 3. Retrieve Logs
+
+```
+GET /logs
+```
+
+* Returns recent evaluation logs for your API key.
+* Supports pagination and time filters.
+
+---
+
+### 4. Delete Log Entry
+
+```
+DELETE /logs/{id}
+```
+
+* Deletes a specific log entry.
+
+---
+
+## ⚡ Modes Recap
+
+* **Insight Mode** → Use for compliance, audits, debugging (rich detail).
+* **Performance Mode** → Use for real-time and high-throughput agents (fast, minimal).
+
+---
+
+## 🔧 Python Example
+
+```python
+import requests, json
+
+# API endpoint for evaluations
+url = "https://inhibitor.infra-5ad.workers.dev/inhibitor"
+
+# Headers include the API key
+headers = {
+    "X-API-Key": "your_api_key",
+    "Content-Type": "application/json"
+}
+
+# Text to evaluate and the selected mode
+payload = {
+    "text": "Here’s my account number 1234-5678-9012",
+    "mode": "insight"
+}
+
+# Send the request
+response = requests.post(url, headers=headers, data=json.dumps(payload))
+
+# Show the JSON response
+print(response.json())
+```
+
+---
+
+## 📌 Best Practices
+
+* Use **insight mode** when developing, auditing, or debugging.
+* Use **performance mode** in production for low-latency, high-volume use.
+* Always **request an API key** from [appliedAIstudio](https://www.appliedai.studio/) before use.
+


### PR DESCRIPTION
## Summary
- document Inhibitor REST API with endpoints and Python usage
- update README with API reference and correct appliedAIstudio link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af47967b84832fbaa91ab30cf1de06