### PR TITLE
Add quickstart notebook and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ This repository is designed for developers, researchers, and teams looking to bu
 
 Explore hands-on examples of how to integrate and test the Inhibitor with different types of agents:
 
-- **[LLM Feedback Agent](notebooks/llm_feedback_agent.ipynb)**  
-  Demonstrates the Reason–Observe–Adjust loop with an LLM assistant. Shows how unsafe recommendations are caught.  
+- **[Quickstart: Inhibitor API](notebooks/quickstart_inhibitor.ipynb)**
+  Minimal example showing how to connect to the API, send text, and view results.
+  [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/quickstart_inhibitor.ipynb)
+
+- **[LLM Feedback Agent](notebooks/llm_feedback_agent.ipynb)**
+  Demonstrates the Reason–Observe–Adjust loop with an LLM assistant. Shows how unsafe recommendations are caught.
   [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/llm_feedback_agent.ipynb)
 
 - **[Real-Time Moderation Agent](notebooks/realtime_moderation_agent.ipynb)**  

--- a/docs/inhibitor-api.md
+++ b/docs/inhibitor-api.md
@@ -130,6 +130,8 @@ response = requests.post(url, headers=headers, data=json.dumps(payload))
 print(response.json())
 ```
 
+👉 Want to see this in action? Try the [Quickstart Notebook](../notebooks/quickstart_inhibitor.ipynb) for a live demo.
+
 ---
 
 ## 📌 Best Practices

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -3,3 +3,9 @@
 This project shows how to build agents that use the Inhibitor for ethical oversight, interruption, and observation. It includes both conceptual guidance and working code examples.
 
 Start with the notebooks or read about how ROA agents function in `/docs/roa-pattern.md`.
+
+---
+
+## Getting Started Fast
+
+New to the Inhibitor? Start with the [Quickstart Notebook](../notebooks/quickstart_inhibitor.ipynb) to make your first API call in under 5 minutes.

--- a/notebooks/quickstart_inhibitor.ipynb
+++ b/notebooks/quickstart_inhibitor.ipynb
@@ -1,0 +1,94 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Quickstart: Using the Inhibitor API\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/appliedaistudio/inhibitor-lab/blob/main/notebooks/quickstart_inhibitor.ipynb)\n",
+        "\n",
+        "This notebook is a **quickstart guide** for using the Inhibitor API.  \n",
+        "In just a few cells, you\u2019ll see how to:\n",
+        "\n",
+        "1. Connect to the Inhibitor service with your API key  \n",
+        "2. Send text for ethical evaluation  \n",
+        "3. Interpret the response  \n",
+        "\n",
+        "By default we\u2019ll use **insight mode** (detailed explanations).  \n",
+        "You can also test **performance mode** (fast, minimal feedback).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Install the requests library\n",
+        "!pip install requests\n",
+        "\n",
+        "# Import required libraries\n",
+        "import os\n",
+        "import requests\n",
+        "import json\n",
+        "\n",
+        "# Set up the Inhibitor service URL and API key\n",
+        "INHIBITOR_URL = os.getenv(\"INHIBITOR_URL\", \"https://inhibitor.infra-5ad.workers.dev/inhibitor\")\n",
+        "INHIBITOR_API_KEY = os.getenv(\"INHIBITOR_API_KEY\")\n",
+        "\n",
+        "# Create request headers with the API key\n",
+        "headers = {\"X-API-Key\": INHIBITOR_API_KEY, \"Content-Type\": \"application/json\"}\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Prepare payload for insight mode\n",
+        "payload = {\"text\": \"How should I invest my money?\", \"mode\": \"insight\"}\n",
+        "\n",
+        "# Call the Inhibitor service and print the response\n",
+        "response = requests.post(INHIBITOR_URL, headers=headers, data=json.dumps(payload))\n",
+        "print(response.json())\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# Prepare payload for performance mode\n",
+        "payload = {\"text\": \"How should I invest my money?\", \"mode\": \"performance\"}\n",
+        "\n",
+        "# Call the Inhibitor service and print the response\n",
+        "response = requests.post(INHIBITOR_URL, headers=headers, data=json.dumps(payload))\n",
+        "print(response.json())\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Next Steps\n",
+        "\n",
+        "- You just made your first call to the Inhibitor API! \ud83c\udf89\n",
+        "- In **insight mode**, you\u2019ll see categories and explanations.  \n",
+        "- In **performance mode**, you\u2019ll see fast flag/no-flag responses.\n",
+        "\n",
+        "For deeper demos:\n",
+        "- See [LLM Feedback Agent](llm_feedback_agent.ipynb) for a full Reason\u2013Observe\u2013Adjust loop.  \n",
+        "- See [AI Security Attacks](ai_security_attacks.ipynb) to test jailbreaks and adversarial inputs.  \n",
+        "- See [Data Handling Agent](data_handling_agent.ipynb) for safe PII handling.\n",
+        "\n",
+        "Full API reference: [../docs/inhibitor-api.md](../docs/inhibitor-api.md)\n"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add quickstart notebook for connecting to Inhibitor API and running insight/performance mode examples
- Highlight quickstart notebook in README and docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af65a55c2c832fadb91433fee08a56