### PR TITLE
docs: emphasize performance-mode defaults and direct feedback handling for agent loops

### DIFF
--- a/docs/inhibitor-api.md
+++ b/docs/inhibitor-api.md
@@ -170,8 +170,9 @@ print(response.json())
 
 ## 📌 Best Practices
 
-* Use **insight mode** when developing, auditing, or debugging.
-* Use **performance mode** in production for low-latency, high-volume use.
+* Default to **performance mode** for most agent loops (including many development and staging runs) to keep feedback fast and iterative.
+* Use **insight mode** selectively when you need detailed rationale (compliance audits, deep debugging, incident retrospectives).
+* In your agent loop, require each post-check message to **respond directly to observed feedback** (no filler text) so corrections are explicit and measurable.
 * Always **request an API key** from [appliedAIstudio](https://www.appliedai.studio/) before use.
 
 ## 🔗 Explore next
@@ -180,4 +181,3 @@ print(response.json())
 - Follow the build sequence in the [Inhibitor Application Sprint](./inhibitor-application-sprint.md) and its [policy-to-rule examples](./policy-rule-examples/README.md) to see how rules surface in `/check` responses.
 - Align deployments with [GDPR compliance](./gdpr-compliance.md), [global edge placement](./global-edge-deployment.md), and the broader [supported regulations](./supported-regulations.md).
 - See how this reference evolved in [Release Notes 1.1](./release-notes/1.1.md) and pair it with the [ROA pattern](./roa-pattern.md) used in the example notebooks.
-

--- a/docs/inhibitor-application-sprint.md
+++ b/docs/inhibitor-application-sprint.md
@@ -55,6 +55,10 @@ This phase scaffolds the Reason–Observe–Adjust cycle. It’s not just about 
 
 Now we activate the Inhibitor. Every reasoning step is checked in real time. Bad paths get flagged, corrected, or blocked. Good decisions get reinforced. The agent doesn’t just avoid mistakes—it starts adjusting its course as it moves.
 
+**Implementation default:** Start with `performance` mode for most runtime checks. Only switch a step (or workflow) to `insight` mode when you need expanded rationale for audits, debugging, or post-incident review.
+
+**Response contract:** After each inhibitor observation, require the agent to respond directly to the feedback in concrete terms (for example: revised action, blocked action, or requested clarification). Avoid courtesy filler so correction signals remain clear and machine-reviewable.
+
 *Example reference: See how the Inhibitor layer interacts with agent decisions in the example notebooks—especially where scoring and annotations are shown.*
 
 **Inputs:**

--- a/docs/roa-pattern.md
+++ b/docs/roa-pattern.md
@@ -69,6 +69,17 @@ This tri-phase loop continues until the agent produces a response that satisfies
 
 ---
 
+### Practical Agent Response Guidance
+
+When wiring ROA into production agents, apply these defaults unless your domain requires otherwise:
+
+* **Default to Performance Mode** during Observe checks. In most loops, agents self-correct effectively from minimal flag feedback, and lower latency improves end-to-end task quality.
+* **Escalate to Insight Mode selectively** for audit workflows, incident analysis, or cases where operators explicitly need narrative rationale.
+* **Require direct remediation responses** after each observation. Each agent turn should address inhibitor feedback explicitly (what changed, what was removed, or why execution is paused), without filler language.
+* **Keep correction messages concise and operational** so downstream evaluators can parse intent and changes quickly.
+
+---
+
 ### Examples
 
 * Inhibitor’s AI assistant evaluating company compliance reports.
@@ -108,7 +119,7 @@ async function runAgent(prompt) {
     // Evaluate the ethical and contextual risk of the current plan
     const evaluation = await callInhibitor(thought);
 
-    // If evaluation returns high risk, adjust the plan
+    // If evaluation returns high risk, apply feedback directly and retry
     if (evaluation.totalSeverity > 0.2) {
       thought = applyInhibitorFeedback(thought, evaluation);
       continue; // Reassess after applying feedback


### PR DESCRIPTION
### Motivation

- Agents in iterative ROA loops typically benefit from lower-latency, flag-only checks and explicit remediation signals to improve stability and throughput. 
- Documentation should reflect field guidance to default to `performance` mode and require concise, direct agent replies to inhibitor observations so downstream systems can parse corrections reliably.

### Description

- Added a new **Practical Agent Response Guidance** section to `docs/roa-pattern.md` recommending `performance` mode by default, selective escalation to `insight`, and concise, direct remediation responses after each observation. 
- Updated `docs/inhibitor-application-sprint.md` (Phase 3) to include an `Implementation default` of `performance` mode and a `Response contract` requiring concrete agent responses to inhibitor feedback. 
- Updated `docs/inhibitor-api.md` Best Practices to prefer `performance` mode for most loops and to require post-check messages that `respond directly to observed feedback` without filler. 
- Small clarifying comment change in the ROA pseudocode to emphasize applying feedback and retrying when checks fail.

### Testing

- Validated the documentation edits with targeted searches using `rg` to confirm new guidance phrases were present. 
- Inspected the updated files with file previews (`nl -ba`) to verify inserted sections and wording. 
- No automated unit or integration tests were required because this is a documentation-only change and there are no runtime code modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d92e5bca70832fb8abe9668d62977d)