### PR TITLE
Clarify Challenge 2 submission guidance for hosted/external agents

### DIFF
--- a/codefest/challenge-2-inhibitor-innovation-red-team/README.md
+++ b/codefest/challenge-2-inhibitor-innovation-red-team/README.md
@@ -56,7 +56,7 @@ Examples:
 
 All teams must include:
 
-- Agent code/notebook and reproducible run steps
+- Agent implementation access details and reproducible run steps (for example: code/notebook in the workspace, or clear instructions for integrating with an externally hosted/existing agent)
 - `README.md` describing track selection, architecture, and assumptions
 - Evidence logs/results demonstrating outcomes
 - A concise summary of key findings and next-step recommendations
@@ -73,6 +73,8 @@ Additional required content by track:
   - Highest-value failed attack and explanation of why defenses held
 
 Teams may use the provided starter assets or any other agent framework/notebook they prefer.
+
+Teams are **not required** to re-upload an agent that is already developed and hosted elsewhere, as long as judges can reliably run or verify the Inhibitor integration through the submitted instructions and evidence.
 
 ## Scoring rubric (100 points)
 


### PR DESCRIPTION
### Motivation
- Soften submission requirements so teams that host agents externally can submit clear integration instructions instead of re-uploading agent code, while preserving reproducibility for judges.

### Description
- Update `codefest/challenge-2-inhibitor-innovation-red-team/README.md` to require "Agent implementation access details and reproducible run steps" (e.g., in-repo code/notebook or integration instructions) and add an explicit note that teams are not required to re-upload agents hosted elsewhere if judges can verify the Inhibitor integration.

### Testing
- Ran `git diff --check` which reported no issues and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d93f2177b4832fb0340e28cb2e3e13)