### PR TITLE
Rewrite Challenge 1 brief in plain, student-friendly language

### DIFF
--- a/codefest/challenge-1-trust-accelerator-campaign/README.md
+++ b/codefest/challenge-1-trust-accelerator-campaign/README.md
@@ -2,36 +2,36 @@
 
 ## Mission
 
-Design and execute an innovative, largely digital awareness campaign that helps CTOs and CIOs building and scaling trustworthy AI understand why and how to adopt Inhibitor.
+Create and run a mostly digital awareness campaign for CTOs and CIOs who are building trustworthy AI programs. Your goal is to show them why and how to adopt Inhibitor.
 
-This challenge is focused on strategy + execution quality, with measurable campaign artifacts that can be judged consistently across teams.
+This challenge is about strong strategy and strong execution, with clear outputs judges can compare across teams.
 
 Your team will:
 
 1. Define a target audience profile for CTO/CIO decision-makers in trustworthy AI programs
-2. Build an awareness campaign concept that is digital-first and innovation-forward
-3. Produce campaign deliverables and measurement plans that can be evaluated by judges
-4. Optionally use AI agents to accelerate campaign research, content generation, testing, or personalization
+2. Build a digital-first campaign concept with a fresh approach
+3. Produce campaign deliverables and a measurement plan judges can evaluate
+4. Optionally use AI agents to speed up research, content creation, testing, or personalization
 
 ## Folder contents
 
-- `starter_agent_policy_to_code.ipynb` - optional starter notebook teams may repurpose for AI-assisted campaign workflows
+- `starter_agent_policy_to_code.ipynb` - optional starter notebook teams can reuse for AI-assisted campaign workflows
 - `codefest/team-workspaces/<your-team>/` - your team submission folder for campaign assets, strategy docs, and evidence
 
 ## Staff-supported steps
 
-- Technical support: staff can help teams with repo structure, submission packaging, and tooling questions
+- Technical support: staff can help with repo structure, submission packaging, and tooling questions
 - Strategy clarification support: staff can clarify challenge boundaries and judging expectations
 - API key support: staff will provide the Inhibitor API key for teams who want product-grounded demos
 - OpenAI API key support: if needed, staff can provide an OpenAI API key for AI-assisted campaign development
 
 ## Basic workflow
 
-1. Define your specific CTO/CIO segment and its trust-related pain points
-2. Design a digital campaign with a clear message architecture and channel plan
+1. Pick your specific CTO/CIO segment and identify its trust-related pain points
+2. Design a digital campaign with a clear message structure and channel plan
 3. Build the required deliverables in your team folder under `codefest/team-workspaces/`
 4. Define measurable campaign KPIs and explain how results would be tracked
-5. Prepare a concise pitch/demo for judges showing innovation and expected impact
+5. Prepare a concise pitch/demo for judges that shows innovation and expected impact
 
 ## Required deliverable package
 
@@ -39,16 +39,16 @@ Teams must submit all items below:
 
 - **Campaign strategy brief (1-2 pages):** target audience, trust problem framing, value proposition, channels, timing
 - **Digital asset kit (minimum 3 assets):** examples include landing page copy/wireframe, executive email sequence, LinkedIn post series, webinar concept, interactive demo storyboard, or short video script
-- **Innovation element description:** explain what is novel (for example, adaptive personalization, agentic outreach workflow, or interactive trust simulation)
+- **Innovation element description:** explain what is new (for example, adaptive personalization, agentic outreach workflow, or interactive trust simulation)
 - **Measurement and scoring plan:** concrete KPIs (for example, qualified sign-ups, CTO/CIO meeting requests, trust-assessment completions)
 - **Judge-ready demo artifact:** a 3-5 minute walkthrough deck or recorded demo that presents the campaign end-to-end
 
 ## Submission requirements
 
-- All deliverables in your team folder under `codefest/team-workspaces/`
-- A `README.md` with run/view instructions for digital artifacts
-- Clear mapping from campaign goals to KPI metrics and success thresholds
-- Optional notes on how AI agents were used to improve campaign execution
+- Put all deliverables in your team folder under `codefest/team-workspaces/`
+- Include a `README.md` with run/view instructions for digital artifacts
+- Show a clear mapping from campaign goals to KPI metrics and success thresholds
+- Optional: include notes on how AI agents were used to improve campaign execution
 
 ## Scoring rubric (100 points)
 
@@ -68,4 +68,4 @@ Teams must submit all items below:
 - Verify the team submitted all required deliverable-package items
 - Score using the five rubric categories above
 - Prioritize campaigns that are both innovative and realistically executable in enterprise contexts
-- Confirm the campaign is predominantly digital and explicitly tailored to CTO/CIO audiences in trustworthy AI
+- Confirm the campaign is mostly digital and explicitly tailored to CTO/CIO audiences in trustworthy AI


### PR DESCRIPTION
### Motivation

- Make the Challenge 1 brief easier for student teams to read by replacing corporate-heavy phrasing with clear, everyday language while keeping the original scope and intent. 
- Preserve the existing deliverables, scoring rubric, and judging guidance so evaluation and requirements remain unchanged.

### Description

- Rewrote `codefest/challenge-1-trust-accelerator-campaign/README.md` to simplify the mission, workflow, submission instructions, and staff judging notes. 
- Kept the same structure, required deliverable list, and rubric point values while changing wording to be more concise and student-focused. 
- Minor wording edits across the file to clarify phrasing (e.g., "digital-first" phrasing, instructions for team folders, and optional AI support notes).

### Testing

- Reviewed the file diff with `git diff -- codefest/challenge-1-trust-accelerator-campaign/README.md` and confirmed changes are wording-only. 
- Inspected the updated file with `nl -ba codefest/challenge-1-trust-accelerator-campaign/README.md | sed -n '1,220p'` to verify formatting and content. 
- All checks passed and the README now reads in concise, everyday language suitable for student participants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d98b3a1d10832fb77351bf3f2448d5)