### PR TITLE
[codex] Surface PoliSwipe at Bytes workspace root

### DIFF
--- a/codefest/team-workspaces/Bytes/PoliSwipe.md
+++ b/codefest/team-workspaces/Bytes/PoliSwipe.md
@@ -1,0 +1,21 @@
+# PoliSwipe
+
+PoliSwipe is Team Bytes' civic engagement app submission.
+
+## Location
+
+- Top-level pointer: `codefest/team-workspaces/Bytes/PoliSwipe.md`
+- App source: `codefest/team-workspaces/Bytes/challenges/challenge-2/`
+- Detailed project write-up: `codefest/team-workspaces/Bytes/challenges/challenge-2/README.md`
+
+## Run
+
+```bash
+cd codefest/team-workspaces/Bytes/challenges/challenge-2
+npm install
+npm run dev
+```
+
+## Why This File Exists
+
+This file makes PoliSwipe clearly visible from the top layer of the `Bytes` workspace while preserving the challenge-based folder structure used by the broader repository.

--- a/codefest/team-workspaces/Bytes/README.md
+++ b/codefest/team-workspaces/Bytes/README.md
@@ -1,6 +1,11 @@
 # Team Bytes
 
 This folder contains our hackathon submission for the Applied AI Studio challenges. We worked across three tracks, so everything is organized by challenge folder.
+
+## Quick Access
+
+**PoliSwipe:** Start with [PoliSwipe.md](./PoliSwipe.md) for the top-level pointer to our civic engagement app, then open `challenges/challenge-2/` for the full source.
+
 ## Team
 
 **Team name:** Bytes
@@ -18,7 +23,8 @@ Folder: `challenges/challenge-1/`
 An interactive UI for reviewing agent activity, policy triggers, intervention logs, and decision traces in one place.
 
 **Challenge 2: PoliSwipe**  
-Folder: `challenges/challenge-2/`  
+Top-level pointer: `PoliSwipe.md`  
+Source folder: `challenges/challenge-2/`  
 A civic engagement app that uses Inhibitor to help users evaluate political content with more trust and transparency.
 
 **Challenge 3: Presented by Bytes**  


### PR DESCRIPTION
## What changed
- added a top-level `PoliSwipe.md` entry point inside `codefest/team-workspaces/Bytes`
- updated the `Bytes` README to point directly to PoliSwipe from the workspace root
- kept the existing challenge-based folder structure intact under `challenges/challenge-2`

## Why
- makes PoliSwipe clearly visible from the uppermost layer of the Bytes folder
- gives reviewers a direct top-level path to the app without moving the existing project layout

## Impact
- reviewers can immediately find PoliSwipe from the Bytes root
- no application logic or runtime behavior changed

## Validation
- locally built the app successfully with `npm run build` before preparing the PR
