### PR TITLE
Update quickstart notebook to print full log entries

### DIFF
--- a/notebooks/quickstart_inhibitor.ipynb
+++ b/notebooks/quickstart_inhibitor.ipynb
@@ -375,14 +375,15 @@
         "if logs_response.status_code != 200:\n",
         "    raise Exception(f\"Logs request failed: {logs_response.status_code} -> {logs_response.text}\")\n",
         "\n",
-        "# Parse and preview the returned log entries\n",
+        "# Parse and collect the returned log entries\n",
         "logs_payload = logs_response.json()\n",
         "log_entries = logs_payload.get(\"logs\", []) if isinstance(logs_payload, dict) else []\n",
         "print(\"Returned logs:\", len(log_entries))\n",
         "\n",
-        "# Print a concise preview of the first few log entries\n",
-        "for idx, entry in enumerate(log_entries[:5], start=1):\n",
-        "    print(f\"{idx}. id={entry.get('id')} created_at={entry.get('created_at')} mode={entry.get('mode')}\")\n"
+        "# Print every log entry in full JSON form for complete visibility\n",
+        "for idx, entry in enumerate(log_entries, start=1):\n",
+        "    print(f\"\\nLog entry {idx}:\")\n",
+        "    print(json.dumps(entry, indent=2, ensure_ascii=False))\n"
       ]
     },
     {


### PR DESCRIPTION
### Motivation

- Improve visibility when inspecting `/logs` responses by printing complete log payloads instead of a terse summary so users can fully inspect each entry.
- Make the example in the quickstart notebook more useful for debugging and schema exploration when developers run the notebook interactively.

### Description

- Modified `notebooks/quickstart_inhibitor.ipynb` to change the logs cell so it collects `logs_payload` and iterates `for idx, entry in enumerate(log_entries, start=1):` instead of limiting to `log_entries[:5]`.
- Replaced the concise preview prints with pretty-printed JSON using `json.dumps(entry, indent=2, ensure_ascii=False)` so each returned log entry is shown in full.
- Updated the inline comment in the cell from `# Parse and preview the returned log entries` to `# Parse and collect the returned log entries` to reflect the new behavior.

### Testing

- Validated the notebook JSON is well-formed with `python -m json.tool notebooks/quickstart_inhibitor.ipynb`, which succeeded.
- Committed the updated notebook and ensured the modified cell appears as intended in the notebook JSON.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e561010460832fb1bdc33b68d05221)